### PR TITLE
Fix setValue incorrectly assuming there is a change when there is none

### DIFF
--- a/src/components/Select2.js
+++ b/src/components/Select2.js
@@ -67,7 +67,7 @@ export default class Select2 extends Component {
   }
 
   setValue(value) {
-    const elVal = this.el.val();
+    const elVal = this.props.multiple ? this.el.val() || [] : this.el.val();
     if (!shallowEqualFuzzy(elVal, value)) {
       this.el.val(value).trigger('change');
     }


### PR DESCRIPTION
When using the component with multiple set to true and there are no option selected, the setValue call will incorrectly assume there is a change (and trigger a change event) because jquery val method returns null instead of an empty array.
This can trigger an infinite loop if you have a controlled component where the state of the host component is synchronized with the selected elements (hosting component will receive the change, update its state and then send the updated state = [] to the component)

Fix consist in checking if the select is in multiple mode and if so, ensuring we return an empty array in case there is no option selected.