### PR TITLE
support dropdownParent option as a string

### DIFF
--- a/src/components/Select2.js
+++ b/src/components/Select2.js
@@ -86,6 +86,10 @@ export default class Select2 extends Component {
     if (this.el) { return; }
     const { defaultValue, value, options } = this.props;
 
+    if (typeof options.dropdownParent === 'string') {
+      options.dropdownParent = $(options.dropdownParent);
+    }
+
     this.el = $(ReactDOM.findDOMNode(this));
     this.el.select2(options);
 


### PR DESCRIPTION
This is a tiny change to allow passing a string to the `dropdownParent` option, so it can be used even when the parent component is rendered isomorphically.

We were unable to use this component initially because we needed the select2 dropdown to be appended to a particular element rather than the `<body>`. Select2 does support a `dropdownParent` option, but unfortunately it requires an element instead of a string (although I feel like it _should_ support a string selector). So perhaps we should be making this pull request to select2 instead, but updating the React component was the most immediate solution to our problem -- and the problem is in some sense specific to react, because the reason we can't pass in the element is because we don't always have access to `document` when we initially `render`.