### PR TITLE
Option elements shouldn't have keys, based on index

### DIFF
--- a/src/components/Select2.js
+++ b/src/components/Select2.js
@@ -156,8 +156,7 @@ export default class Select2 extends Component {
   makeOption(item, k) {
     if (this.isObject(item)) {
       const { id, text, ...itemParams } = item;
-      const key = 'option-' + k + '-' + id;
-      return (<option key={key} value={id} {...itemParams}>{text}</option>);
+      return (<option key={`option-${k}-${id}`} value={id} {...itemParams}>{text}</option>);
     }
 
     return (<option key={`option-${k}`} value={item}>{item}</option>);

--- a/src/components/Select2.js
+++ b/src/components/Select2.js
@@ -156,7 +156,8 @@ export default class Select2 extends Component {
   makeOption(item, k) {
     if (this.isObject(item)) {
       const { id, text, ...itemParams } = item;
-      return (<option key={`option-${k}`} value={id} {...itemParams}>{text}</option>);
+      const sanitized_id = id + '';
+      return (<option key={`option-${sanitized_id}`} value={id} {...itemParams}>{text}</option>);
     }
 
     return (<option key={`option-${k}`} value={item}>{item}</option>);

--- a/src/components/Select2.js
+++ b/src/components/Select2.js
@@ -156,8 +156,8 @@ export default class Select2 extends Component {
   makeOption(item, k) {
     if (this.isObject(item)) {
       const { id, text, ...itemParams } = item;
-      const sanitized_id = id + '';
-      return (<option key={`option-${sanitized_id}`} value={id} {...itemParams}>{text}</option>);
+      const key = 'option-' + k + '-' + id;
+      return (<option key={key} value={id} {...itemParams}>{text}</option>);
     }
 
     return (<option key={`option-${k}`} value={item}>{item}</option>);

--- a/src/components/Select2.js
+++ b/src/components/Select2.js
@@ -156,7 +156,7 @@ export default class Select2 extends Component {
   makeOption(item, k) {
     if (this.isObject(item)) {
       const { id, text, ...itemParams } = item;
-      return (<option key={`option-${k}-${id}`} value={id} {...itemParams}>{text}</option>);
+      return (<option key={`option-${id}`} value={id} {...itemParams}>{text}</option>);
     }
 
     return (<option key={`option-${k}`} value={item}>{item}</option>);


### PR DESCRIPTION
Keys in `<option/>` ekenebts shouldn't depend on key index here : https://github.com/rkit/react-select2-wrapper/blob/master/src/components/Select2.js#L159
```jsx
/* This */
return (<option key={`option-${k}`} value={id} {...itemParams}>{text}</option>);
/* should be changed to this: */
return (<option key={`option-${id}`} value={id} {...itemParams}>{text}</option>);
```
Otherwise it doesn't re-render options, when options list is changed.

Also, probably `<optgroup>` keys could have been made of their children's keys, but that seemed overhead to me.