### PR TITLE
Fix allowClear option [Closes #63]

### DIFF
--- a/examples/src/components/Tags.js
+++ b/examples/src/components/Tags.js
@@ -26,6 +26,13 @@ export default class Tags extends Component {
         { text: 'documents', id: 3 },
         { text: 'discussion', id: 4 },
       ],
+      value11: 1,
+      data11: [
+        { text: 'bug', id: 1 },
+        { text: 'feature', id: 2 },
+        { text: 'documents', id: 3 },
+        { text: 'discussion', id: 4 },
+      ],
       placeholder9: 'search by tags',
     };
   }
@@ -287,6 +294,28 @@ export default class Tags extends Component {
     );
   }
 
+  example11() {
+    const { value11, data11, onChange11 } = this.state;
+    return (
+      <div>
+        Add a new item and set a new `onChange` event<br/>
+        <Select2
+          multiple={false}
+          data={data11}
+          defaultValue={ 1 }
+          value={ value11 }
+          onChange={(e) => { this.setState({value11: e.target.value}) }}
+          options={{
+            placeholder: 'search by tags',
+            allowClear: true
+          }}
+        />
+        —
+        Click "x" to clear
+      </div>
+    );
+  }
+
   render() {
     return (
       <div>
@@ -299,7 +328,7 @@ export default class Tags extends Component {
         {this.example7()}<br/>
         {this.example8()}<br/>
         {this.example9()}<br/>
-        {this.example10()}<br/>
+        {this.example11()}<br/>
       </div>
     );
   }

--- a/examples/src/components/Tags.js
+++ b/examples/src/components/Tags.js
@@ -295,7 +295,7 @@ export default class Tags extends Component {
   }
 
   example11() {
-    const { value11, data11, onChange11 } = this.state;
+    const { value11, data11 } = this.state;
     return (
       <div>
         Add a new item and set a new `onChange` event<br/>
@@ -304,10 +304,10 @@ export default class Tags extends Component {
           data={data11}
           defaultValue={ 1 }
           value={ value11 }
-          onChange={(e) => { this.setState({value11: e.target.value}) }}
+          onChange={(e) => { this.setState({ value11: e.target.value }); }}
           options={{
             placeholder: 'search by tags',
-            allowClear: true
+            allowClear: true,
           }}
         />
         —

--- a/src/components/Select2.js
+++ b/src/components/Select2.js
@@ -105,7 +105,7 @@ export default class Select2 extends Component {
     const newValue = this.prepareValue(value, defaultValue);
     const currentValue = multiple ? this.el.val() || [] : this.el.val();
 
-    if (!shallowEqualFuzzy(currentValue, newValue) || this.forceUpdateValue) {
+    if (!this.fuzzyValuesEqual(currentValue, newValue) || this.forceUpdateValue) {
       const onChange = this.props.onChange;
 
       if (this.initialRender && onChange) {
@@ -119,6 +119,11 @@ export default class Select2 extends Component {
       }
       this.forceUpdateValue = false;
     }
+  }
+
+  fuzzyValuesEqual(currentValue, newValue) {
+    return (currentValue === null && newValue === '') ||
+      shallowEqualFuzzy(currentValue, newValue);
   }
 
   destroySelect2(withCallbacks = true) {


### PR DESCRIPTION
When the `allowClear` option is enabled and that same component has a `onChange` callback, clicking the clear icon will cause an infinite loop. The root cause seems to be that`this.el.val()` returns `null` when previously set to an empty string, which is what happens when the input is cleared. As expected `shallowEqualFuzzy` returns `false` when comparing `null` to `''` which causes an infinite `onChange` callback loop.

The new `fuzzyValuesEqual` method returns `true` when `currentValue` is `null` and `newValue` is equal to an empty string, otherwise it calls `shallowEqualFuzzy` which was the previous behavior.

I've also updated the examples with a select2 component set to `allowClear` which can be used to manually test the new behavior. Let me know if there is anything you'd like me to change. Thanks! 😄 