### PR TITLE
restore INVALID HOST HEADER error(Because of webpack update)

### DIFF
--- a/examples/server.js
+++ b/examples/server.js
@@ -10,6 +10,7 @@ config.entry.app.push(
 
 new WebpackDevServer(webpack(config), {
   publicPath: config.output.publicPath,
+  historyApiFallback: true,
   disableHostCheck: true,
   hot: true,
   stats: {

--- a/examples/server.js
+++ b/examples/server.js
@@ -10,7 +10,7 @@ config.entry.app.push(
 
 new WebpackDevServer(webpack(config), {
   publicPath: config.output.publicPath,
-  historyApiFallback: true,
+  disableHostCheck: true,
   hot: true,
   stats: {
     colors: true,


### PR DESCRIPTION
When I download this project, use npm to install its dependencies. I access my server's 3000 port after that. But it goes wrong. Browser hint me that INVALID HOST HEADER. Beacause of webpack is updated which made it's more restrictive to access. Check it.