### PR TITLE
Update Select2.js

### DIFF
--- a/src/components/Select2.js
+++ b/src/components/Select2.js
@@ -181,7 +181,7 @@ export default class Select2 extends Component {
   makeOption(item) {
     if (this.isObject(item)) {
       const { id, text, ...itemParams } = item;
-      return (<option key={`option-${id}`} value={id} {...itemParams}>{text}</option>);
+      return (<option key={id} value={id} {...itemParams}>{text}</option>);
     }
 
     return (<option key={`option-${item}`} value={item}>{item}</option>);


### PR DESCRIPTION
Resolved key issue.
Warning: Encountered two children with the same key, `option-undefined`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.